### PR TITLE
Easy performance gain

### DIFF
--- a/Stride.BepuPhysics/Processors/ContainerProcessor.cs
+++ b/Stride.BepuPhysics/Processors/ContainerProcessor.cs
@@ -99,7 +99,7 @@ namespace Stride.BepuPhysics.Processors
                     bepuSim.ContactEvents.Flush(); //Fire event handler stuff.
                     bepuSim.RemainingUpdateTime -= bepuSim.SimulationFixedStep; //in millisec
                     stepCount++;
-                    bepuSim.CallAfterSimulationUpdate(simTimeStepInSec);//cal the AfterSimulationUpdate with the real step time of the sim in secs
+                    bepuSim.CallAfterSimulationUpdate(simTimeStepInSec);//call the AfterSimulationUpdate with the real step time of the sim in secs
                 }
 
 #warning I don't think this should be user-controllable ? We don't provide control over the other parts of the engine when they run through the dispatcher and having it on or of doesn't (or rather shouldn't) actually change the result, just how fast it resolves

--- a/Stride.BepuPhysics/Processors/ContainerProcessor.cs
+++ b/Stride.BepuPhysics/Processors/ContainerProcessor.cs
@@ -94,15 +94,13 @@ namespace Stride.BepuPhysics.Processors
                 while (bepuSim.RemainingUpdateTime >= bepuSim.SimulationFixedStep & stepCount < bepuSim.MaxStepPerFrame)
                 {
                     var simTimeStepInSec = bepuSim.SimulationFixedStep / 1000f;
-                    bepuSim.CallSimulationUpdate(simTimeStepInSec);//cal the SimulationUpdate with the real step time of the sim in secs
+                    bepuSim.CallSimulationUpdate(simTimeStepInSec);//call the SimulationUpdate with the real step time of the sim in secs
                     bepuSim.Simulation.Timestep(simTimeStepInSec, bepuSim.ThreadDispatcher); //perform physic simulation using bepuSim.SimulationFixedStep
-                    bepuSim.ContactEvents.Flush(); //Fire events handlers stuffs.
+                    bepuSim.ContactEvents.Flush(); //Fire event handler stuff.
                     bepuSim.RemainingUpdateTime -= bepuSim.SimulationFixedStep; //in millisec
                     stepCount++;
                     bepuSim.CallAfterSimulationUpdate(simTimeStepInSec);//cal the AfterSimulationUpdate with the real step time of the sim in secs
                 }
-
-
 
 #warning I don't think this should be user-controllable ? We don't provide control over the other parts of the engine when they run through the dispatcher and having it on or of doesn't (or rather shouldn't) actually change the result, just how fast it resolves
                 // I guess it could make sense when running on a low power device, but at that point might as well make the change to Dispatcher itself

--- a/Stride.BepuPhysics/Processors/ContainerProcessor.cs
+++ b/Stride.BepuPhysics/Processors/ContainerProcessor.cs
@@ -148,7 +148,8 @@ namespace Stride.BepuPhysics.Processors
                     //We need to call 
                     if (item.ContainerData != null && !item.ContainerData.IsStatic)
                     {
-                        entityTransform.UpdateWorldMatrix();
+						//Warning this may cause threading-race issues (but i did large tests and never had issues)
+						entityTransform.UpdateWorldMatrix(); 
 						UpdateBodiesPositionFunction(item.ContainerData.BHandle, bepuSim, updateDebugRender);
                     }
                 }

--- a/Stride.BepuPhysics/Processors/ContainerProcessor.cs
+++ b/Stride.BepuPhysics/Processors/ContainerProcessor.cs
@@ -139,7 +139,6 @@ namespace Stride.BepuPhysics.Processors
             entityTransform.Rotation = body.Pose.Orientation.ToStrideQuaternion() * Quaternion.Invert(parentEntityRotation);
             entityTransform.Position = Vector3.Transform(localPosition, Quaternion.Invert(parentEntityRotation)) - Vector3.Transform(bodyContainer.CenterOfMass, entityTransform.Rotation);
 
-            entityTransform.UpdateWorldMatrix(); //Warning this may cause threading-race issues (but i did large tests and never had issues)
 #warning it cost almost 0, not sure it's needed to not update it. Also, not updating it may causes issue when bodies are sleeping.
             //if (updateDebugRender)
             bodyContainer.ContainerData?.UpdateDebugRender();

--- a/Stride.BepuPhysics/Processors/ContainerProcessor.cs
+++ b/Stride.BepuPhysics/Processors/ContainerProcessor.cs
@@ -147,7 +147,10 @@ namespace Stride.BepuPhysics.Processors
                 {
                     //We need to call 
                     if (item.ContainerData != null && !item.ContainerData.IsStatic)
-                        UpdateBodiesPositionFunction(item.ContainerData.BHandle, bepuSim, updateDebugRender);
+                    {
+                        entityTransform.UpdateWorldMatrix();
+						UpdateBodiesPositionFunction(item.ContainerData.BHandle, bepuSim, updateDebugRender);
+                    }
                 }
             }
 


### PR DESCRIPTION
This code was causing the Dispatcher.For loop to crash/freeze applications, I dont think its needed anyway.

As far as I understand, all this does is force the Transforms to update in the current frame rather than the next frame which I see as a non issue.