### PR TITLE
make internals public

### DIFF
--- a/Stride.BepuPhysics/Systems/ContainerProcessor.cs
+++ b/Stride.BepuPhysics/Systems/ContainerProcessor.cs
@@ -15,8 +15,8 @@ public class ContainerProcessor : EntityProcessor<ContainerComponent>
 {
     internal readonly UnsortedO1List<StaticComponent, Matrix4x4> Statics = new();
 
-    internal ShapeCacheSystem ShapeCache { get; private set; } = null!;
-    internal Dictionary<ContainerComponent, ContainerComponent>.Enumerator ComponentDataEnumerator => base.ComponentDatas.GetEnumerator();
+    public ShapeCacheSystem ShapeCache { get; private set; } = null!;
+    public Dictionary<ContainerComponent, ContainerComponent>.Enumerator ComponentDataEnumerator => base.ComponentDatas.GetEnumerator();
 
     public BepuConfiguration BepuConfiguration { get; private set; } = null!;
 

--- a/Stride.BepuPhysics/Systems/ShapeCacheSystem.cs
+++ b/Stride.BepuPhysics/Systems/ShapeCacheSystem.cs
@@ -14,7 +14,7 @@ using Mesh = BepuPhysics.Collidables.Mesh;
 
 namespace Stride.BepuPhysics.Systems;
 
-internal class ShapeCacheSystem
+public class ShapeCacheSystem
 {
     private IGame _game;
 


### PR DESCRIPTION
I wanted to create a custom library in my game project and needed to read shape data from the Container processor but couldnt because it was in a different assembly. This should allow users to use these properties for their own use in seperate projects.