### PR TITLE
Fixed Cancel getting called in SimulationUpdateComponent before it started

### DIFF
--- a/Stride.BepuPhysics/Components/SimulationUpdateComponent.cs
+++ b/Stride.BepuPhysics/Components/SimulationUpdateComponent.cs
@@ -16,7 +16,8 @@ public abstract class SimulationUpdateComponent : SyncScript, ISimulationUpdate
         {
             if (_simulationIndex != value)
             {
-                Cancel();
+				if (_started)
+					Cancel();
                 _simulationIndex = value;
                 if (_started)
                     Start();


### PR DESCRIPTION
Quick fix to make it so that cancel doesn't get called before start in SimulationUpdateComponent